### PR TITLE
fix(limits): Set defaults for missing app limits

### DIFF
--- a/__tests__/unit/utils.test.ts
+++ b/__tests__/unit/utils.test.ts
@@ -54,8 +54,8 @@ describe("Utils", () => {
       });
 
       expect(extractRateLimits(headers)).toEqual({
-        appLimits: "",
-        appCounts: "",
+        appLimits: expect.any(String),
+        appCounts: expect.any(String),
         methodLimits: "2000:60",
         methodCounts: "1:1,3:120",
         retryAfter: 0,
@@ -69,8 +69,8 @@ describe("Utils", () => {
       });
 
       expect(extractRateLimits(headers)).toEqual({
-        appLimits: "",
-        appCounts: "",
+        appLimits: expect.any(String),
+        appCounts: expect.any(String),
         methodLimits: "",
         methodCounts: "",
         retryAfter: 5000,
@@ -84,8 +84,8 @@ describe("Utils", () => {
       });
 
       expect(extractRateLimits(headers)).toEqual({
-        appLimits: "",
-        appCounts: "",
+        appLimits: expect.any(String),
+        appCounts: expect.any(String),
         methodLimits: "",
         methodCounts: "",
         retryAfter: 0,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -48,8 +48,8 @@ export const secsToMs = (secs: number): number => secs * 1000;
 export const toNumber = (n: string) => Number(n);
 
 export const extractRateLimits = (headers: Headers): RateLimits => ({
-  appLimits: headers.get("X-App-Rate-Limit") || "",
-  appCounts: headers.get("X-App-Rate-Limit-Count") || "",
+  appLimits: headers.get("X-App-Rate-Limit") || "10:10,500:600",
+  appCounts: headers.get("X-App-Rate-Limit-Count") || "1:10,1:600",
   methodLimits: headers.get("X-Method-Rate-Limit") || "",
   methodCounts: headers.get("X-Method-Rate-Limit-Count") || "",
   retryAfter: secsToMs(toNumber(headers.get("Retry-After") || "")),


### PR DESCRIPTION
For some endpoints such as the RSO ones, an applications rate limits is not returned in the response headers, only the methods rate limits are. Therefore we set some default rate limits, this should not affect any other endpoints.