### PR TITLE
fix the reservoir limit

### DIFF
--- a/__tests__/unit/rate-limiter.test.ts
+++ b/__tests__/unit/rate-limiter.test.ts
@@ -139,34 +139,34 @@ describe("rate-limiter", () => {
       rateLimiter.received().currentReservoir();
     });
 
-    test("it should not update the reservoir limits if the API returns higher limits", async () => {
-      mockedCreateRateLimiterOptions.mockReturnValue({
-        reservoirRefreshAmount: 100,
-        reservoir: 3,
-      });
-      const rateLimiter = Substitute.for<Bottleneck>();
-      const rateLimits = { limits: "100:10", counts: "3:10" };
-      const counts = { EXECUTING: 0 } as Bottleneck.Counts;
-      rateLimiter.currentReservoir().resolves(5);
-
-      await synchronizeRateLimiters([rateLimiter], rateLimits, counts);
-
-      expect(mockedCreateRateLimiterOptions).toHaveBeenCalledWith(
-        "100:10",
-        "3:10"
-      );
-      rateLimiter.received().updateSettings({ reservoir: 5 });
-    });
-
-    test("it should update the reservoir limits if the API returns lower limits", async () => {
+    test("it should update the reservoir limits if the API returns higher limits", async () => {
       mockedCreateRateLimiterOptions.mockReturnValue({
         reservoirRefreshAmount: 10,
         reservoir: 7,
       });
       const rateLimiter = Substitute.for<Bottleneck>();
+      const rateLimits = { limits: "10:10", counts: "3:10" };
+      const counts = { EXECUTING: 0 } as Bottleneck.Counts;
+      rateLimiter.currentReservoir().resolves(8);
+
+      await synchronizeRateLimiters([rateLimiter], rateLimits, counts);
+
+      expect(mockedCreateRateLimiterOptions).toHaveBeenCalledWith(
+        "10:10",
+        "3:10"
+      );
+      rateLimiter.received().updateSettings({ reservoir: 7 });
+    });
+
+    test("it should update the reservoir limits if the API returns lower limits", async () => {
+      mockedCreateRateLimiterOptions.mockReturnValue({
+        reservoirRefreshAmount: 10,
+        reservoir: 3,
+      });
+      const rateLimiter = Substitute.for<Bottleneck>();
       const rateLimits = { limits: "10:10", counts: "7:10" };
       const counts = { EXECUTING: 0 } as Bottleneck.Counts;
-      rateLimiter.currentReservoir().resolves(5);
+      rateLimiter.currentReservoir().resolves(4);
 
       await synchronizeRateLimiters([rateLimiter], rateLimits, counts);
 
@@ -176,12 +176,12 @@ describe("rate-limiter", () => {
     test("it should update the reservoir limits if we have many requests inflight", async () => {
       mockedCreateRateLimiterOptions.mockReturnValue({
         reservoirRefreshAmount: 10,
-        reservoir: 3,
+        reservoir: 7,
       });
       const rateLimiter = Substitute.for<Bottleneck>();
       const rateLimits = { limits: "10:10", counts: "3:10" };
       const counts = { EXECUTING: 5 } as Bottleneck.Counts;
-      rateLimiter.currentReservoir().resolves(5);
+      rateLimiter.currentReservoir().resolves(8);
 
       await synchronizeRateLimiters([rateLimiter], rateLimits, counts);
 

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -77,14 +77,9 @@ export const synchronizeRateLimiters = async (
           limitsArr[index],
           countsArr[index]
         );
-        const rateLimitsLeftFromRiot =
-          (newRateLimits.reservoirRefreshAmount || 0) -
-          (newRateLimits.reservoir || 0);
+        const rateLimitsLeftFromRiot = newRateLimits.reservoir || 0;
+        const newReservoir = rateLimitsLeftFromRiot - requestsInFlight;
 
-        const newReservoir = Math.min(
-          currentReservoir,
-          rateLimitsLeftFromRiot - requestsInFlight
-        );
         limiter.updateSettings({ reservoir: newReservoir });
         return limiter;
       }


### PR DESCRIPTION
# Context
As described [here](https://github.com/SGrondin/bottleneck#reservoir-intervals) the reservoir is the number of jobs the limiter is allowed to execute. 
Once the value reaches 0, it stops starting new jobs. 
This number should decrease over the time or should be initialized by the `reservoirRefreshAmount` value once the `reservoirRefreshInterval` is reached.

In the Riot API context when we have headers like `App-Rate-Limit: 10:10,100:120` and `App-Rate-Limit-Count: 3:10,3:120` then the reservoir limit for the first limiter should be `10-3` -> `7` and for the second limiter `100-3` -> `97`.

# Changes
- Update the `synchronizeRateLimiters` logic
- Update reservoir limit value in the tests

# Further Details
The reservoir value doesn't depend on the `currentReservoir` anymore.
It's just based on the `*-Rate-Limit-Count` header (to set the next reservoir value) minus the number of running methods. 
