### PR TITLE
fix: update endpoints

### DIFF
--- a/__tests__/unit/extractor.test.ts
+++ b/__tests__/unit/extractor.test.ts
@@ -45,22 +45,22 @@ describe("Extractor", () => {
       [
         "CHAMPION_MASTERY.GET_ALL_CHAMPIONS",
         METHODS.CHAMPION_MASTERY.GET_ALL_CHAMPIONS,
-        { summonerId: "1234" },
+        { encryptedPUUID: "1234" },
       ],
       [
         "CHAMPION_MASTERY.GET_CHAMPION_MASTERY",
         METHODS.CHAMPION_MASTERY.GET_CHAMPION_MASTERY,
-        { summonerId: "1234", championId: "53" },
+        { encryptedPUUID: "1234", championId: "53" },
       ],
       [
         "CHAMPION_MASTERY.GET_TOP_CHAMPIONS",
         METHODS.CHAMPION_MASTERY.GET_TOP_CHAMPIONS,
-        { summonerId: "1234" },
+        { encryptedPUUID: "1234" },
       ],
       [
         "CHAMPION_MASTERY.GET_CHAMPION_MASTERY_SCORE",
         METHODS.CHAMPION_MASTERY.GET_CHAMPION_MASTERY_SCORE,
-        { summonerId: "1234" },
+        { encryptedPUUID: "1234" },
       ],
       // CHAMPIONS
       [

--- a/__tests__/unit/index.test.ts
+++ b/__tests__/unit/index.test.ts
@@ -38,7 +38,7 @@ describe("@fightmegg/riot-rate-limtier", () => {
     };
     const host = "https://euw1.api.riotgames.com";
     const path =
-      "/lol/champion-mastery/v4/champion-masteries/by-summoner/12345";
+      "/lol/champion-mastery/v4/champion-masteries/by-puuid/12345";
 
     beforeEach(() => {
       jest.resetAllMocks();

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -225,13 +225,13 @@ export const METHODS = {
   },
   CHAMPION_MASTERY: {
     GET_ALL_CHAMPIONS:
-      "/lol/champion-mastery/v4/champion-masteries/by-summoner/:summonerId",
+      "/lol/champion-mastery/v4/champion-masteries/by-puuid/:encryptedPUUID",
     GET_CHAMPION_MASTERY:
-      "/lol/champion-mastery/v4/champion-masteries/by-summoner/:summonerId/by-champion/:championId",
+      "/lol/champion-mastery/v4/champion-masteries/by-puuid/:encryptedPUUID/by-champion/:championId",
     GET_TOP_CHAMPIONS:
-      "/lol/champion-mastery/v4/champion-masteries/by-summoner/:summonerId/top",
+      "/lol/champion-mastery/v4/champion-masteries/by-puuid/:encryptedPUUID/top",
     GET_CHAMPION_MASTERY_SCORE:
-      "/lol/champion-mastery/v4/scores/by-summoner/:summonerId",
+      "/lol/champion-mastery/v4/scores/by-puuid/:encryptedPUUID",
   },
   CHAMPION: {
     GET_CHAMPION_ROTATIONS: "/lol/platform/v3/champion-rotations",

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -111,6 +111,9 @@ export interface METHODS {
     GET_PERCENTILES_BY_ID: string;
     GET_PLAYER_DATA_BY_PUUID: string;
   };
+  LOL_STATUS: {
+    GET_PLATFORM_DATA: string;
+  };
   LOR_DECK: {
     GET_DECKS_FOR_PLAYER: string;
     POST_CREATE_DECK_FOR_PLAYER: string;
@@ -265,6 +268,9 @@ export const METHODS = {
     GET_PERCENTILES_BY_ID:
       "/lol/challenges/v1/challenges/:challengeId/percentiles",
     GET_PLAYER_DATA_BY_PUUID: "/lol/challenges/v1/player-data/:puuid",
+  },
+  LOL_STATUS: {
+    GET_PLATFORM_DATA: "/lol/status/v4/platform-data",
   },
   LOR_DECK: {
     GET_DECKS_FOR_PLAYER: "/lor/deck/v1/decks/me",


### PR DESCRIPTION
old mastery-v4 endpoints have been removed as of jan 2024, and have been replaced with endpoints using user's PUUID.

this PR makes breaking changes as all parameters for CHAMPION_MASTERY have been changed from `summonerId` to `encryptedPUUID`

This PR also adds in lol-status-v4. 