### PR TITLE
spectator v5 endpoints update

### DIFF
--- a/__tests__/e2e/match.test.ts
+++ b/__tests__/e2e/match.test.ts
@@ -4,13 +4,14 @@ import { PlatformId } from "../../src/@types";
 import { RiotRateLimiter, METHODS, HOST } from "../../src/index";
 
 const riotAPIKey = process.env.X_RIOT_API_KEY || "";
+const puuid = process.env.PUUID || "";
 
 describe("E2E", () => {
   test("Get MatchIds By PUUID", async () => {
     const limiter = new RiotRateLimiter();
 
     const createHost = compile(HOST, { encode: encodeURIComponent });
-    const createAccountPath = compile(METHODS.SUMMONER.GET_BY_SUMMONER_NAME, {
+    const createAccountPath = compile(METHODS.SUMMONER.GET_BY_PUUID, {
       encode: encodeURIComponent,
     });
     const createMatchListPath = compile(METHODS.MATCH_V5.GET_IDS_BY_PUUID, {
@@ -25,7 +26,7 @@ describe("E2E", () => {
     const account = await limiter.execute({
       url: `https://${createHost({
         platformId: PlatformId.EUW1,
-      })}${createAccountPath({ summonerName: "Demos Kratos" })}`,
+      })}${createAccountPath({ puuid: puuid })}`,
       options,
     });
     const resp = await limiter.execute({
@@ -43,7 +44,7 @@ describe("E2E", () => {
     const limiter = new RiotRateLimiter();
 
     const createHost = compile(HOST, { encode: encodeURIComponent });
-    const createAccountPath = compile(METHODS.SUMMONER.GET_BY_SUMMONER_NAME, {
+    const createAccountPath = compile(METHODS.SUMMONER.GET_BY_PUUID, {
       encode: encodeURIComponent,
     });
     const createMatchListPath = compile(METHODS.MATCH_V5.GET_IDS_BY_PUUID, {
@@ -58,7 +59,7 @@ describe("E2E", () => {
     const account = await limiter.execute({
       url: `https://${createHost({
         platformId: PlatformId.EUW1,
-      })}${createAccountPath({ summonerName: "Demos Kratos" })}`,
+      })}${createAccountPath({ puuid: puuid })}`,
       options,
     });
 

--- a/__tests__/e2e/summoner.test.ts
+++ b/__tests__/e2e/summoner.test.ts
@@ -4,18 +4,19 @@ import { PlatformId } from "../../src/@types";
 import { RiotRateLimiter, METHODS, HOST } from "../../src/index";
 
 const riotAPIKey = process.env.X_RIOT_API_KEY || "";
+const puuid = process.env.PUUID || "";
 
 describe("E2E", () => {
-  test("Get Summoner By SummonerName", async () => {
+  test("Get Summoner By Puuid", async () => {
     const limiter = new RiotRateLimiter();
 
     const createHost = compile(HOST, { encode: encodeURIComponent });
-    const createPath = compile(METHODS.SUMMONER.GET_BY_ACCESS_TOKEN, {
+    const createPath = compile(METHODS.SUMMONER.GET_BY_PUUID, {
       encode: encodeURIComponent,
     });
     const url = `https://${createHost({
       platformId: PlatformId.EUW1,
-    })}${createPath()}`;
+    })}${createPath({ puuid: puuid })}`;
     const options = {
       headers: {
         "X-Riot-Token": riotAPIKey,
@@ -26,7 +27,6 @@ describe("E2E", () => {
       "id",
       "accountId",
       "puuid",
-      "name",
       "profileIconId",
       "revisionDate",
       "summonerLevel",

--- a/__tests__/e2e/summoner.test.ts
+++ b/__tests__/e2e/summoner.test.ts
@@ -10,19 +10,18 @@ describe("E2E", () => {
     const limiter = new RiotRateLimiter();
 
     const createHost = compile(HOST, { encode: encodeURIComponent });
-    const createPath = compile(METHODS.SUMMONER.GET_BY_SUMMONER_NAME, {
+    const createPath = compile(METHODS.SUMMONER.GET_BY_ACCESS_TOKEN, {
       encode: encodeURIComponent,
     });
     const url = `https://${createHost({
       platformId: PlatformId.EUW1,
-    })}${createPath({ summonerName: "Demos Kratos" })}`;
+    })}${createPath()}`;
     const options = {
       headers: {
         "X-Riot-Token": riotAPIKey,
       },
     };
     const resp = await limiter.execute({ url, options });
-    expect(resp.name).toEqual("Demos Kratos");
     expect(resp).toContainAllKeys([
       "id",
       "accountId",

--- a/__tests__/unit/extractor.test.ts
+++ b/__tests__/unit/extractor.test.ts
@@ -250,11 +250,6 @@ describe("Extractor", () => {
         { accountId: "1234" },
       ],
       [
-        "SUMMONER.GET_BY_SUMMONER_NAME",
-        METHODS.SUMMONER.GET_BY_SUMMONER_NAME,
-        { summonerName: "Demos Kratos" },
-      ],
-      [
         "SUMMONER.GET_BY_PUUID",
         METHODS.SUMMONER.GET_BY_PUUID,
         { puuid: "12334" },

--- a/__tests__/unit/index.test.ts
+++ b/__tests__/unit/index.test.ts
@@ -37,8 +37,7 @@ describe("@fightmegg/riot-rate-limtier", () => {
       "X-Method-Rate-Limit-Count": "1:1,3:120",
     };
     const host = "https://euw1.api.riotgames.com";
-    const path =
-      "/lol/champion-mastery/v4/champion-masteries/by-puuid/12345";
+    const path = "/lol/champion-mastery/v4/champion-masteries/by-puuid/12345";
 
     beforeEach(() => {
       jest.resetAllMocks();

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,8 +1,7 @@
 import type { Config } from "@jest/types";
 
 process.env.RIOT_LOL_API_KEY = "661771";
-process.env.PUUID =
-  "JjKdGcffExfOCsfimlsP2QOnoXA-lZCJL9jM2KeLkmEw6UGxi1ZguLAEaCs_eOY3zJeyaZO1KmcMDQ";
+process.env.PUUID = "";
 const config: Config.InitialOptions = {
   verbose: true,
   coverageDirectory: ".jest/coverage",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,8 @@
 import type { Config } from "@jest/types";
 
-process.env.RIOT_LOL_API_KEY = "661771";
-
+process.env.X_RIOT_API_KEY = "";
+process.env.PUUID =
+  "JjKdGcffExfOCsfimlsP2QOnoXA-lZCJL9jM2KeLkmEw6UGxi1ZguLAEaCs_eOY3zJeyaZO1KmcMDQ";
 const config: Config.InitialOptions = {
   verbose: true,
   coverageDirectory: ".jest/coverage",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,7 +1,8 @@
 import type { Config } from "@jest/types";
 
 process.env.RIOT_LOL_API_KEY = "661771";
-process.env.PUUID = "";
+process.env.PUUID =
+  "8bJQbDi6uFIgefQA6Y79yxff_1bCHNopb1eHlq3p7Ic2oeXgYTvNnfGahtWyJ6qqAue3uK6wiZmMWQ";
 const config: Config.InitialOptions = {
   verbose: true,
   coverageDirectory: ".jest/coverage",

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,6 @@
 import type { Config } from "@jest/types";
 
-process.env.X_RIOT_API_KEY = "";
+process.env.RIOT_LOL_API_KEY = "661771";
 process.env.PUUID =
   "JjKdGcffExfOCsfimlsP2QOnoXA-lZCJL9jM2KeLkmEw6UGxi1ZguLAEaCs_eOY3zJeyaZO1KmcMDQ";
 const config: Config.InitialOptions = {

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -302,8 +302,8 @@ export const METHODS = {
   },
   SPECTATOR: {
     GET_GAME_BY_SUMMONER_ID:
-      "/lol/spectator/v4/active-games/by-summoner/:summonerId",
-    GET_FEATURED_GAMES: "/lol/spectator/v4/featured-games",
+      "/lol/spectator/v5/active-games/by-summoner/:summonerId",
+    GET_FEATURED_GAMES: "/lol/spectator/v5/featured-games",
   },
   SUMMONER: {
     GET_BY_RSO_PUUID: "/fulfillment/v1/summoners/by-puuid/:rsoPuuid",

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -147,7 +147,6 @@ export interface METHODS {
   SUMMONER: {
     GET_BY_RSO_PUUID: string;
     GET_BY_ACCOUNT_ID: string;
-    GET_BY_SUMMONER_NAME: string;
     GET_BY_PUUID: string;
     GET_BY_SUMMONER_ID: string;
     GET_BY_ACCESS_TOKEN: string;
@@ -309,7 +308,6 @@ export const METHODS = {
     GET_BY_RSO_PUUID: "/fulfillment/v1/summoners/by-puuid/:rsoPuuid",
     GET_BY_ACCESS_TOKEN: "/lol/summoner/v4/summoners/me",
     GET_BY_ACCOUNT_ID: "/lol/summoner/v4/summoners/by-account/:accountId",
-    GET_BY_SUMMONER_NAME: "/lol/summoner/v4/summoners/by-name/:summonerName",
     GET_BY_PUUID: "/lol/summoner/v4/summoners/by-puuid/:puuid",
     GET_BY_SUMMONER_ID: "/lol/summoner/v4/summoners/:summonerId",
   },


### PR DESCRIPTION
@OllieJennings Hi, i have been working on a discord bot involving a few riot API calls like the spectator one. Your package has been of much help so i would like to help with implementing the v5 of the spectator api. 

I couldn't find any other points in the rate limiter that need changing, as the API endpoints did not change much and the DTO typings are in the riot-api package. I will try to update whatever needs updating on that package aswell!

